### PR TITLE
Adding CSRF support

### DIFF
--- a/templates/forms/_edit.html
+++ b/templates/forms/_edit.html
@@ -21,6 +21,7 @@
 	<form method="post" accept-charset="UTF-8" data-saveshortcut="1">
 		<input type="hidden" name="action" value="formBuilder/forms/saveForm">
 		<input type="hidden" name="redirect" value="formbuilder/forms">
+		{{ getCsrfInput() }}
 		{% if form.id %}<input type="hidden" name="formId" value="{{ form.id }}">{% endif %}
 
 		{{ forms.textField({


### PR DESCRIPTION
Adding form creation CSRF protection.

http://buildwithcraft.com/help/csrf-protection

Should fail gracefully if CSRF Protection is not enabled.